### PR TITLE
Changes to InstantiateAddressablePrefab

### DIFF
--- a/Runtime/Code/InstantiateAddressablePrefab.cs
+++ b/Runtime/Code/InstantiateAddressablePrefab.cs
@@ -14,8 +14,15 @@ namespace LOP
         [SerializeField] private string address;
         [Tooltip("When the prefab is instantiated, and this is true, the prefab's position and rotation will be set to 0")]
         [SerializeField] private bool setPositionAndRotationToZero = true;
-        [Tooltip("setPositionAndRotationToZero would work relative to it's parent")]
+        [Tooltip("When the prefab is instantiated, and this is true, the prefab's position will be set to 0")]
+        [SerializeField] private bool setPositionToZero = true;
+        [Tooltip("When the prefab is instantiated, and this is true, the prefab's rotation will be set to 0")]
+        [SerializeField] private bool setRotationToZero = true;
+        [Tooltip("setPosition/RotationToZero would work relative to it's parent")]
         [SerializeField] private bool useLocalPositionAndRotation = true;
+        [Tooltip("When the prefab is instantiated, and this is true, the prefab's local scale will be set to value of newLocalScale")]
+        [SerializeField] private bool overrideLocalScale;
+        [SerializeField] private Vector3 newLocalScale = Vector3.one;
         [Tooltip("Wether the Refresh method will be called in the editor")]
         [SerializeField] private bool refreshInEditor = true;
         [SerializeField, HideInInspector] private bool hasNetworkIdentity;
@@ -38,13 +45,13 @@ namespace LOP
         /// </summary>
         public void Refresh()
         {
-            if (Application.isEditor && !refreshInEditor)
-                return;
-
             if (instance)
             {
                 LOPUtil.DestroyImmediateSafe(instance, true);
             }
+
+            if (Application.isEditor && !refreshInEditor)
+                return;
 
             if (string.IsNullOrWhiteSpace(address) || string.IsNullOrEmpty(address))
             {
@@ -68,25 +75,48 @@ namespace LOP
                 instance = Instantiate(prefab, transform);
             }
 
-            if(instance) 
+            if (instance) 
             {
+#if UNITY_EDITOR
+                instance.AddComponent<InstantiateProtection>();
+#endif
+
                 instance.hideFlags |= HideFlags.DontSaveInEditor | HideFlags.DontSaveInBuild | HideFlags.NotEditable;
                 foreach (Transform t in instance.GetComponentsInChildren<Transform>())
                 {
                     t.gameObject.hideFlags = instance.hideFlags;
                 }
+
                 if (setPositionAndRotationToZero)
                 {
                     Transform t = instance.transform;
-                    if (useLocalPositionAndRotation)
+                    if (setPositionToZero)
                     {
-                        t.localPosition = Vector3.zero;
-                        t.localRotation = Quaternion.identity;
+                        if (useLocalPositionAndRotation)
+                        {
+                            t.localPosition = Vector3.zero;
+                        }
+                        else
+                        {
+                            t.position = Vector3.zero;
+                        }
                     }
-                    else
+                    if (setRotationToZero)
                     {
-                        t.SetPositionAndRotation(Vector3.zero, Quaternion.identity);
+                        if (useLocalPositionAndRotation)
+                        {
+                            t.localRotation = Quaternion.identity;
+                        }
+                        else
+                        {
+                            t.rotation = Quaternion.identity;
+                        }
                     }
+                }
+
+                if (overrideLocalScale)
+                {
+                    t.localScale = newLocalScale;
                 }
             }
         }

--- a/Runtime/Code/InstantiateProtection.cs
+++ b/Runtime/Code/InstantiateProtection.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace LOP
+{
+    /// <summary>
+    /// Destroys GameObject if it was created via Instantiate
+    /// </summary>
+    [ExecuteAlways]
+    public class InstantiateProtection : MonoBehaviour
+    {
+        [SerializeField, HideInInspector]
+        private bool instantiated;
+
+        private void Awake()
+        {
+            if (instantiated)
+            {
+                LOPUtil.DestroyImmediateSafe(gameObject, true);
+            }
+            instantiated = true;
+        }
+    }
+}

--- a/Runtime/Code/InstantiateProtection.cs.meta
+++ b/Runtime/Code/InstantiateProtection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a68a5447667d4284d87359abee3f4835
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added new fields for more granular control. You can now override only position or only rotation, but also now you can overwrite scale of instantiated object.
Also added a protection component that will be added to all instantiated objects while in the editor, that will destroy the gameObject if it was created via instantiation. In particular it solves the problem of duplicating objects while `InstantiateAddressablePrefab` is active and `refreshInEditor` is true, which would previously result in extra dead objects.